### PR TITLE
Fix: Make withdrawal status filter case-insensitive

### DIFF
--- a/controllers/withdrawal.controller.js
+++ b/controllers/withdrawal.controller.js
@@ -440,8 +440,18 @@ exports.adminGetRequests = async (req, res) => {
     console.log(`[WithdrawCtrl - adminGetRequests] Admin fetching requests. Status: ${status || 'All'}, Page: ${page}, Limit: ${limit}`);
 
     const filter = {};
-    if (status && ['Pending', 'Processing', 'Completed', 'Rejected', 'Failed'].includes(status)) {
-        filter.status = status;
+    if (status) {
+        const lowerStatus = status.toLowerCase();
+        const validStatuses = {
+            pending: 'Pending',
+            processing: 'Processing',
+            completed: 'Completed',
+            rejected: 'Rejected',
+            failed: 'Failed'
+        };
+        if (validStatuses[lowerStatus]) {
+            filter.status = validStatuses[lowerStatus];
+        }
     }
 
     try {


### PR DESCRIPTION
The admin withdrawal requests endpoint was not correctly filtering by status due to case sensitivity. The `status` query parameter was being compared directly against a list of capitalized statuses ('Pending', 'Completed', etc.).

This commit modifies the `adminGetRequests` function in `controllers/withdrawal.controller.js` to convert the incoming `status` query parameter to lowercase before validation. It then maps the lowercase status to the correct capitalized version (as defined in the `WithdrawalRequest` model's enum) for the database query.

This ensures that filtering for pending withdrawals (e.g., `?status=pending`) now works as expected, aligning its behavior with the deposit requests filter.